### PR TITLE
Use new cc facilities, cleanup and adjust to naming conventions

### DIFF
--- a/src/task-dispatcher/container/spmc_queue.hh
+++ b/src/task-dispatcher/container/spmc_queue.hh
@@ -260,13 +260,13 @@ private:
     std::shared_ptr<Deque<T>> deque;
 
 public:
-    explicit Worker() : deque(nullptr) {} // invalid state default ctor
+    explicit Worker() = default; // invalid state default ctor
+
     // Deferred init setter
     void setDeque(std::shared_ptr<Deque<T>> d) { deque = std::move(d); }
 
     // Regular ctor
     explicit Worker(std::shared_ptr<Deque<T>> d) : deque(std::move(d)) {}
-
 
     // Copy constructor.
     // There can only be one worker end.

--- a/src/task-dispatcher/container/task.cc
+++ b/src/task-dispatcher/container/task.cc
@@ -1,14 +1,14 @@
 #include "task.hh"
 
-td::container::detail::CallableWrapper::~CallableWrapper() = default;
+td::container::detail::callable_wrapper::~callable_wrapper() = default;
 
-void td::container::detail::FuncPtrWrapper::call() { func_ptr(userdata); }
+void td::container::detail::func_ptr_wrapper::call() { _func_ptr(_userdata); }
 
-static_assert(sizeof(td::container::Task) == td::system::l1_cacheline_size, "Task exceeds cacheline size");
+static_assert(sizeof(td::container::task) == td::system::l1_cacheline_size, "Task exceeds cacheline size");
 
 // is_trivial_v is too strong since the ctor has a default init
 // the valid / invalid can be entirely removed if strict constraints are utilized
-static_assert(std::is_trivially_destructible_v<td::container::Task>, "Task not trivial");
-static_assert(std::is_trivially_copyable_v<td::container::Task>, "Task not trivial");
-static_assert(std::is_trivially_copy_assignable_v<td::container::Task>, "Task not trivial");
-static_assert(std::is_trivially_move_assignable_v<td::container::Task>, "Task not trivial");
+static_assert(std::is_trivially_destructible_v<td::container::task>, "Task not trivial");
+static_assert(std::is_trivially_copyable_v<td::container::task>, "Task not trivial");
+static_assert(std::is_trivially_copy_assignable_v<td::container::task>, "Task not trivial");
+static_assert(std::is_trivially_move_assignable_v<td::container::task>, "Task not trivial");

--- a/src/task-dispatcher/container/task.cc
+++ b/src/task-dispatcher/container/task.cc
@@ -4,11 +4,5 @@ td::container::detail::callable_wrapper::~callable_wrapper() = default;
 
 void td::container::detail::func_ptr_wrapper::call() { _func_ptr(_userdata); }
 
-static_assert(sizeof(td::container::task) == td::system::l1_cacheline_size, "Task exceeds cacheline size");
-
-// is_trivial_v is too strong since the ctor has a default init
-// the valid / invalid can be entirely removed if strict constraints are utilized
-static_assert(std::is_trivially_destructible_v<td::container::task>, "Task not trivial");
-static_assert(std::is_trivially_copyable_v<td::container::task>, "Task not trivial");
-static_assert(std::is_trivially_copy_assignable_v<td::container::task>, "Task not trivial");
-static_assert(std::is_trivially_move_assignable_v<td::container::task>, "Task not trivial");
+static_assert(sizeof(td::container::task) == td::system::l1_cacheline_size, "task exceeds cacheline size");
+static_assert(std::is_trivial_v<td::container::task>, "task is not trivial");

--- a/src/task-dispatcher/container/task.hh
+++ b/src/task-dispatcher/container/task.hh
@@ -18,9 +18,10 @@ struct callable_wrapper
     virtual void call() = 0;
 };
 
-template <class T, std::enable_if_t<std::is_invocable_r_v<void, T>, int> = 0>
+template <class T>
 struct lambda_wrapper final : callable_wrapper
 {
+    static_assert (std::is_invocable_r_v<void, T>, "Lambda must have no arguments");
     explicit lambda_wrapper(T&& t) : _lambda(std::move(t)) {}
     void call() final override { _lambda(); }
 

--- a/src/task-dispatcher/scheduler.cc
+++ b/src/task-dispatcher/scheduler.cc
@@ -29,7 +29,7 @@ namespace
 auto constexpr s_use_workstealing = true;
 }
 
-thread_local td::Scheduler* td::Scheduler::s_current_scheduler = nullptr;
+thread_local td::Scheduler* td::Scheduler::sCurrentScheduler = nullptr;
 
 namespace td
 {
@@ -184,7 +184,7 @@ struct Scheduler::callback_funcs
 
         // Register thread local current scheduler variable
         Scheduler* const scheduler = worker_arg->owning_scheduler;
-        scheduler->s_current_scheduler = scheduler;
+        scheduler->sCurrentScheduler = scheduler;
 
         s_tls.reset();
         s_tls.thread_index = worker_arg->index;
@@ -602,7 +602,7 @@ void td::Scheduler::start(td::container::task main_task)
         native::set_current_thread_affinity(0);
 
         s_tls.reset();
-        s_current_scheduler = this;
+        sCurrentScheduler = this;
 
         // Create main fiber on this thread
         native::create_main_fiber(s_tls.thread_fiber);
@@ -720,8 +720,8 @@ void td::Scheduler::start(td::container::task main_task)
             // Reset counter handles
             mCounterHandles.reset();
 
-            // Clear s_current_scheduler
-            s_current_scheduler = nullptr;
+            // Clear sCurrentScheduler
+            sCurrentScheduler = nullptr;
         }
     }
 }

--- a/src/task-dispatcher/scheduler.cc
+++ b/src/task-dispatcher/scheduler.cc
@@ -513,6 +513,11 @@ td::Scheduler::Scheduler(scheduler_config const& config)
     static_assert(invalid_counter == std::numeric_limits<counter_index_t>().max(), "Invalid counter index corrupt");
 }
 
+td::Scheduler::~Scheduler()
+{
+    // Intentionally left empty
+}
+
 void td::Scheduler::submitTasks(td::container::task* tasks, unsigned num_tasks, td::sync& sync)
 {
     counter_index_t counter_index;

--- a/src/task-dispatcher/scheduler.hh
+++ b/src/task-dispatcher/scheduler.hh
@@ -51,6 +51,7 @@ public:
 
 public:
     explicit Scheduler(scheduler_config const& config = scheduler_config());
+    ~Scheduler();
 
     // Launch the scheduler with the given main task
     void start(container::task main_task);

--- a/src/task-dispatcher/scheduler.hh
+++ b/src/task-dispatcher/scheduler.hh
@@ -61,12 +61,12 @@ public:
     void wait(td::sync& sync, bool pinnned = false, int target = 0);
 
     // The scheduler running the current task
-    [[nodiscard]] static Scheduler& current() { return *s_current_scheduler; }
+    [[nodiscard]] static Scheduler& current() { return *sCurrentScheduler; }
     // Returns true if called from inside the scheduler
-    [[nodiscard]] static bool isInsideScheduler() { return s_current_scheduler != nullptr; }
+    [[nodiscard]] static bool isInsideScheduler() { return sCurrentScheduler != nullptr; }
 
 private:
-    static thread_local Scheduler* s_current_scheduler;
+    static thread_local Scheduler* sCurrentScheduler;
 
 public:
     using fiber_index_t = unsigned;

--- a/src/task-dispatcher/td.hh
+++ b/src/task-dispatcher/td.hh
@@ -57,7 +57,8 @@ void wait_for_unpinned(STs&... syncs)
 
 [[nodiscard]] inline bool is_scheduler_alive() { return Scheduler::isInsideScheduler(); }
 
-// Future
+// Future, move only
+// Can be obtained when submitting invocables with return values
 template <class T>
 struct future
 {


### PR DESCRIPTION
- Switch to `cc::vector` and `cc::array` in `td::Scheduler`, clean up
- use `cc::placement_new` in `td::task`, adjust task naming
- use `cc::unique_ptr` for `td::future`