### PR TITLE
Kw/develop

### DIFF
--- a/src/task-dispatcher/common/spin_lock.hh
+++ b/src/task-dispatcher/common/spin_lock.hh
@@ -33,4 +33,20 @@ public:
     SpinLock& operator=(SpinLock const& other) = delete;
     SpinLock& operator=(SpinLock&& other) noexcept = delete;
 };
+
+template <typename T>
+class LockGuard
+{
+public:
+    explicit LockGuard(T& mutex) : mMutex(mutex) { mMutex.lock(); }
+    ~LockGuard() { mMutex.unlock(); }
+
+    LockGuard(const LockGuard&) = delete;
+    LockGuard(LockGuard&& other) noexcept = delete;
+    LockGuard& operator=(const LockGuard&) = delete;
+    LockGuard& operator=(LockGuard&& other) noexcept = delete;
+
+private:
+    T& mMutex;
+};
 }

--- a/src/task-dispatcher/container/mpsc_queue.hh
+++ b/src/task-dispatcher/container/mpsc_queue.hh
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <limits>
+#include <cstddef>
 
 #include <clean-core/assert.hh>
 
@@ -10,8 +10,8 @@ namespace td::container
 template <class T, size_t N>
 class FIFOQueue
 {
-    static_assert (N > 0);
-    static_assert(N < size_t(std::numeric_limits<int>::max()), "FIFOQueue too large");
+    static_assert(N > 0);
+    static_assert(N < size_t(-1), "FIFOQueue too large");
 
 private:
     int mHead = -1;

--- a/src/task-dispatcher/native/thread.hh
+++ b/src/task-dispatcher/native/thread.hh
@@ -6,7 +6,7 @@
 #include <clean-core/defer.hh>
 #include <clean-core/macros.hh>
 
-#ifdef _WIN32
+#ifdef CC_OS_WINDOWS
 
 #include <atomic>
 

--- a/src/task-dispatcher/native/thread.hh
+++ b/src/task-dispatcher/native/thread.hh
@@ -170,14 +170,14 @@ inline bool set_stack_size(pthread_attr_t& thread_attributes, size_t stack_size)
 
 inline bool create_thread(size_t stack_size, thread_start_func_t start_routine, void* arg, thread_t* return_thread)
 {
-    pthread_attr_t threadAttr;
-    pthread_attr_init(&threadAttr);
-    CC_DEFER { pthread_attr_destroy(&threadAttr); };
+    pthread_attr_t thread_attr;
+    pthread_attr_init(&thread_attr);
+    CC_DEFER { pthread_attr_destroy(&thread_attr); };
 
-    if (!detail::set_stack_size(threadAttr, stack_size))
+    if (!detail::set_stack_size(thread_attr, stack_size))
         return false;
 
-    auto const create_res = pthread_create(&return_thread->native, &threadAttr, start_routine, arg);
+    auto const create_res = pthread_create(&return_thread->native, &thread_attr, start_routine, arg);
     return create_res == 0;
 }
 

--- a/src/task-dispatcher/scheduler.cc
+++ b/src/task-dispatcher/scheduler.cc
@@ -1,7 +1,6 @@
 #include "scheduler.hh"
 
 #include <limits> // Only for sanity check static_asserts
-#include <mutex>  // std::lock_guard
 
 #include <clean-core/allocate.hh>
 #include <clean-core/assert.hh>
@@ -325,7 +324,7 @@ bool td::Scheduler::getNextTask(td::container::task& task)
         fiber_index_t resumable_fiber_index;
         bool got_resumable;
         {
-            std::lock_guard lg(local_thread.pinned_resumable_fibers_lock);
+            LockGuard lg(local_thread.pinned_resumable_fibers_lock);
             got_resumable = local_thread.pinned_resumable_fibers.dequeue(resumable_fiber_index);
         }
 
@@ -338,7 +337,7 @@ bool td::Scheduler::getNextTask(td::container::task& task)
             else
             {
                 // Received fiber is not cleaned up yet, re-enqueue
-                std::lock_guard lg(local_thread.pinned_resumable_fibers_lock);
+                LockGuard lg(local_thread.pinned_resumable_fibers_lock);
                 local_thread.pinned_resumable_fibers.enqueue(resumable_fiber_index);
             }
             // TODO: Restart or fallthrough?
@@ -478,7 +477,7 @@ void td::Scheduler::counterCheckWaitingFibers(td::Scheduler::atomic_counter_t& c
                 // The waiting fiber is pinned to a certain thread, store it there
                 auto& pinned_thread = mThreads[slot.pinned_thread_index];
 
-                std::lock_guard lg(pinned_thread.pinned_resumable_fibers_lock);
+                LockGuard lg(pinned_thread.pinned_resumable_fibers_lock);
                 pinned_thread.pinned_resumable_fibers.enqueue(slot.fiber_index);
             }
 

--- a/src/task-dispatcher/scheduler.cc
+++ b/src/task-dispatcher/scheduler.cc
@@ -658,8 +658,7 @@ void td::Scheduler::start(td::container::task main_task)
             // Prepare worker arg
             callback_funcs::worker_arg_t* const worker_arg = cc::alloc<callback_funcs::worker_arg_t>(callback_funcs::worker_arg_t{i, this, thread_deques});
 
-            auto success = native::create_thread(unsigned(mFiberStackSize) + thread_stack_overhead_safety, callback_funcs::worker_func, worker_arg, i,
-                                                 &thread.native);
+            auto success = native::create_thread(mFiberStackSize + thread_stack_overhead_safety, callback_funcs::worker_func, worker_arg, i, &thread.native);
             CC_ASSERT(success && "Failed to create worker thread");
         }
     }


### PR DESCRIPTION
- Fix infinite runtime recursion in variadic `td::wait_for` if called with the wrong type (or just a `td::sync const`)
- Add `submit_batched_n`, which additionally passes the batch index to the lambda
- Adjust some naming, native thread API cleanup