### PR TITLE
Simplify task, fix TSan-reported vtable data race

### DIFF
--- a/src/task-dispatcher/common/math_intrin.hh
+++ b/src/task-dispatcher/common/math_intrin.hh
@@ -39,16 +39,7 @@ inline uint32_t cas(volatile uint32_t* dst, uint32_t cmp, uint32_t exc)
 #endif
 }
 
-inline uint64_t rdtsc()
-{
-#ifdef _MSC_VER
-    return __rdtsc();
-#elif defined __GNUC__
-    unsigned int lo, hi;
-    __asm__ __volatile__("rdtsc" : "=a"(lo), "=d"(hi));
-    return (static_cast<uint64_t>(hi) << 32) | lo;
-#endif
-}
+inline uint64_t rdtsc() { return __rdtsc(); }
 }
 
 namespace td::math

--- a/src/task-dispatcher/common/math_intrin.hh
+++ b/src/task-dispatcher/common/math_intrin.hh
@@ -3,52 +3,28 @@
 #include <cstdint>
 
 #ifdef _MSC_VER
-#include <clean-core/native/win32_sanitized.hh>
+#include <intrin.h>
+#else
+#include <x86intrin.h>
 #endif
 
 namespace td::intrin
 {
-inline uint32_t bsr(uint32_t v)
+inline unsigned long bsr(uint32_t v) noexcept
 {
-#ifdef _MSC_VER
-    DWORD index;
+    unsigned long index;
     _BitScanReverse(&index, v);
     return index;
-#elif defined __GNUC__
-    return sizeof(v) * 8 - __builtin_clz(v);
-#endif
 }
 
-inline uint32_t bsr(uint64_t v)
+inline unsigned long bsr(uint64_t v) noexcept
 {
-#ifdef _MSC_VER
-    DWORD index;
+    unsigned long index;
     _BitScanReverse64(&index, v);
     return index;
-#elif defined __GNUC__
-    return sizeof(v) * 8 - __builtin_clzll(v);
-#endif
 }
 
-inline uint32_t cas(volatile uint32_t* dst, uint32_t cmp, uint32_t exc)
-{
-#ifdef _MSC_VER
-    return _InterlockedCompareExchange(dst, exc, cmp);
-#elif defined __GNUC__
-    return __sync_val_compare_and_swap(dst, cmp, exc);
-#endif
-}
-
-inline uint64_t rdtsc()
-{
-#ifdef _MSC_VER
-    return __rdtsc();
-#elif defined __GNUC__
-    unsigned int lo, hi;
-    __asm__ __volatile__("rdtsc" : "=a"(lo), "=d"(hi));
-    return (static_cast<uint64_t>(hi) << 32) | lo;
-#endif
-}
+inline unsigned long long rdtsc() noexcept { return __rdtsc(); }
 }
 
 namespace td::math

--- a/src/task-dispatcher/common/math_intrin.hh
+++ b/src/task-dispatcher/common/math_intrin.hh
@@ -3,28 +3,52 @@
 #include <cstdint>
 
 #ifdef _MSC_VER
-#include <intrin.h>
-#else
-#include <x86intrin.h>
+#include <clean-core/native/win32_sanitized.hh>
 #endif
 
 namespace td::intrin
 {
-inline unsigned long bsr(uint32_t v) noexcept
+inline uint32_t bsr(uint32_t v)
 {
-    unsigned long index;
+#ifdef _MSC_VER
+    DWORD index;
     _BitScanReverse(&index, v);
     return index;
+#elif defined __GNUC__
+    return sizeof(v) * 8 - __builtin_clz(v);
+#endif
 }
 
-inline unsigned long bsr(uint64_t v) noexcept
+inline uint32_t bsr(uint64_t v)
 {
-    unsigned long index;
+#ifdef _MSC_VER
+    DWORD index;
     _BitScanReverse64(&index, v);
     return index;
+#elif defined __GNUC__
+    return sizeof(v) * 8 - __builtin_clzll(v);
+#endif
 }
 
-inline unsigned long long rdtsc() noexcept { return __rdtsc(); }
+inline uint32_t cas(volatile uint32_t* dst, uint32_t cmp, uint32_t exc)
+{
+#ifdef _MSC_VER
+    return _InterlockedCompareExchange(dst, exc, cmp);
+#elif defined __GNUC__
+    return __sync_val_compare_and_swap(dst, cmp, exc);
+#endif
+}
+
+inline uint64_t rdtsc()
+{
+#ifdef _MSC_VER
+    return __rdtsc();
+#elif defined __GNUC__
+    unsigned int lo, hi;
+    __asm__ __volatile__("rdtsc" : "=a"(lo), "=d"(hi));
+    return (static_cast<uint64_t>(hi) << 32) | lo;
+#endif
+}
 }
 
 namespace td::math

--- a/src/task-dispatcher/container/task.cc
+++ b/src/task-dispatcher/container/task.cc
@@ -1,8 +1,4 @@
 #include "task.hh"
 
-td::container::detail::callable_wrapper::~callable_wrapper() = default;
-
-void td::container::detail::func_ptr_wrapper::call() { _func_ptr(_userdata); }
-
 static_assert(sizeof(td::container::task) == td::system::l1_cacheline_size, "task exceeds cacheline size");
 static_assert(std::is_trivial_v<td::container::task>, "task is not trivial");

--- a/src/task-dispatcher/container/task.hh
+++ b/src/task-dispatcher/container/task.hh
@@ -1,7 +1,9 @@
 #pragma once
 
-#include <utility>
+#include <functional>
+#include <type_traits>
 
+#include <clean-core/move.hh>
 #include <clean-core/new.hh>
 #include <clean-core/typedefs.hh>
 
@@ -9,125 +11,92 @@
 
 namespace td::container
 {
-namespace detail
-{
-struct callable_wrapper
-{
-    virtual ~callable_wrapper();
-    virtual void call() = 0;
-};
-
-template <class T>
-struct lambda_wrapper final : callable_wrapper
-{
-    static_assert(std::is_invocable_r_v<void, T>, "Lambda must have no arguments");
-    explicit lambda_wrapper(T&& t) : _lambda(std::move(t)) {}
-    void call() final override { _lambda(); }
-
-    lambda_wrapper(lambda_wrapper const&) = delete;
-    lambda_wrapper(lambda_wrapper&&) noexcept = delete;
-    lambda_wrapper& operator=(lambda_wrapper const&) = delete;
-    lambda_wrapper& operator=(lambda_wrapper&&) noexcept = delete;
-
-private:
-    T _lambda;
-};
-
-struct func_ptr_wrapper final : callable_wrapper
-{
-    using func_ptr_t = void (*)(void* _userdata);
-
-    explicit func_ptr_wrapper(func_ptr_t func_ptr, void* userdata) : _func_ptr(func_ptr), _userdata(userdata) {}
-    void call() final override;
-
-    func_ptr_wrapper(func_ptr_wrapper const&) = delete;
-    func_ptr_wrapper(func_ptr_wrapper&&) noexcept = delete;
-    func_ptr_wrapper& operator=(func_ptr_wrapper const&) = delete;
-    func_ptr_wrapper& operator=(func_ptr_wrapper&&) noexcept = delete;
-
-private:
-    func_ptr_t _func_ptr;
-    void* _userdata;
-};
-}
-
 // POD-struct storing tasks, from either a captureful lambda (of limited size), or a func ptr + void* userdata
 // Additionally stores arbitrary metadata of a fixed size
 //
-// NOTE: If initialized from a lambda, cleanup() must get called exactly once on any copy of that instance, before the last of them is
-// either destroyed or re-initialized. Zero calls could leak captured non-trivial-dtor types like std::vector, more than one call would read after
-// free. This restriction allows task to be POD, but makes usage of this struct outside of rigid scenarios inadvisable.
+// NOTE: If initialized from a lambda, execute_and_cleanup() or cleanup() must get called exactly once on any copy of that instance, before the last
+// of them is either destroyed or re-initialized. Zero calls could leak captured non-trivial-dtor types like std::vector, more than one call would
+// read after free. This restriction allows task to be POD, but makes usage of this struct outside of rigid scenarios inadvisable.
 struct task
 {
 public:
     using default_metadata_t = cc::uint16;
+    using function_ptr_t = void (*)(void*);
+    using execute_and_cleanup_function_t = void(cc::byte*, bool);
+
     static auto constexpr task_size = td::system::l1_cacheline_size;
-    static auto constexpr metadata_size = sizeof(default_metadata_t);
-    static auto constexpr usable_buffer_size = task_size - metadata_size;
-    static_assert(sizeof(detail::func_ptr_wrapper) <= usable_buffer_size, "task is too small to hold func_ptr_wrapper");
+    static constexpr auto usable_buffer_size = task_size - sizeof(default_metadata_t) - sizeof(execute_and_cleanup_function_t*);
+    using buffer_t = cc::byte[usable_buffer_size];
 
 private:
-    cc::byte _buffer[task_size];
+    buffer_t _buffer;
+    default_metadata_t _metadata;
+    execute_and_cleanup_function_t* _exec_cleanup_func;
 
 public:
     // == Constructors ==
     explicit task() = default;
 
     // From a lambda of the form void(void)
-    template <class T, std::enable_if_t<std::is_invocable_r_v<void, T>, int> = 0>
+    template <class T, std::enable_if_t<std::is_invocable_r_v<void, T> && std::is_class_v<T>, int> = 0>
     explicit task(T&& l)
     {
         lambda(std::forward<T>(l));
     }
 
     // From function pointer and userdata void*
-    explicit task(detail::func_ptr_wrapper::func_ptr_t func_ptr, void* userdata = nullptr) { ptr(func_ptr, userdata); }
+    explicit task(function_ptr_t func_ptr, void* userdata = nullptr) { ptr(func_ptr, userdata); }
 
 public:
     // == Deferred initialization ==
 
     // From a lambda of the form void()
-    template <class T, std::enable_if_t<std::is_invocable_r_v<void, T>, int> = 0>
+    template <class T, std::enable_if_t<std::is_invocable_r_v<void, T> && std::is_class_v<T>, int> = 0>
     void lambda(T&& l)
     {
-        static_assert(sizeof(detail::lambda_wrapper<T>) <= usable_buffer_size, "Lambda capture exceeds task buffer size");
-        new (cc::placement_new, static_cast<void*>(_buffer)) detail::lambda_wrapper<T>(std::forward<T>(l));
+        static_assert(std::is_class_v<T> && std::is_invocable_r_v<void, T>);
+        static_assert(sizeof(T) <= sizeof(buffer_t)); // && alignof(T) <= alignof(buffer_t));
+
+        new (cc::placement_new, _buffer) T(cc::move(l));
+
+        _exec_cleanup_func = [](cc::byte* buf, bool do_execute) {
+            T& ref = *reinterpret_cast<T*>(buf);
+            if (do_execute)
+                std::invoke(ref);
+            ref.~T();
+        };
     }
 
     // From function pointer of the form void(void*) and userdata void*
-    void ptr(detail::func_ptr_wrapper::func_ptr_t func_ptr, void* userdata = nullptr)
+    void ptr(function_ptr_t func_ptr, void* userdata = nullptr)
     {
-        new (cc::placement_new, static_cast<void*>(_buffer)) detail::func_ptr_wrapper(func_ptr, userdata);
+        using fptr_t = function_ptr_t;
+
+        new (cc::placement_new, _buffer) fptr_t(func_ptr);
+        new (cc::placement_new, _buffer + sizeof(fptr_t)) void*(userdata);
+
+        _exec_cleanup_func = [](cc::byte* buf, bool do_execute) {
+            if (do_execute)
+            {
+                fptr_t& ref = *reinterpret_cast<fptr_t*>(buf);
+                void*& ref_arg = *reinterpret_cast<void**>(buf + sizeof(fptr_t));
+
+                ref(ref_arg);
+            }
+        };
     }
 
 public:
     // Write metadata into the reserved block
-    template <class T = default_metadata_t>
-    void set_metadata(T data)
-    {
-        static_assert(sizeof(T) <= metadata_size, "Metadata too large");
-        *static_cast<T*>(static_cast<void*>(_buffer + usable_buffer_size)) = data;
-    }
+    void set_metadata(default_metadata_t data) { _metadata = data; }
 
     // Read metadata from the reserved block
-    template <class T = default_metadata_t>
-    T get_metadata() const
-    {
-        static_assert(sizeof(T) <= metadata_size, "Metadata too large");
-        return *static_cast<T const*>(static_cast<void const*>(_buffer + usable_buffer_size));
-    }
-
-    // Execute the contained task
-    void execute() { (*reinterpret_cast<detail::callable_wrapper*>(_buffer)).call(); }
-
-    // Clean up the possibly stored lambda, invalidating the task
-    void cleanup() { (*reinterpret_cast<detail::callable_wrapper*>(_buffer)).~callable_wrapper(); }
+    default_metadata_t get_metadata() const { return _metadata; }
 
     // Execute the contained task and clean it up afterwards (invalidates task)
-    void execute_and_cleanup()
-    {
-        execute();
-        cleanup();
-    }
+    void execute_and_cleanup() { _exec_cleanup_func(_buffer, true); }
+
+    // Only clean up the contained task (invalidates task)
+    void cleanup() { _exec_cleanup_func(_buffer, false); }
 };
 }

--- a/src/task-dispatcher/native/thread.hh
+++ b/src/task-dispatcher/native/thread.hh
@@ -11,7 +11,6 @@
 #include <atomic>
 
 #include <process.h>
-
 #include <clean-core/native/win32_sanitized.hh>
 
 #else

--- a/src/task-dispatcher/native/thread.hh
+++ b/src/task-dispatcher/native/thread.hh
@@ -11,6 +11,7 @@
 #include <atomic>
 
 #include <process.h>
+
 #include <clean-core/native/win32_sanitized.hh>
 
 #else

--- a/src/task-dispatcher/scheduler.cc
+++ b/src/task-dispatcher/scheduler.cc
@@ -25,7 +25,7 @@ namespace
 // If false:
 //  use a single, fixed size MPMC queue
 //      in Scheduler::mTasks
-auto constexpr s_use_workstealing = true;
+auto constexpr s_use_workstealing = false;
 }
 
 thread_local td::Scheduler* td::Scheduler::sCurrentScheduler = nullptr;

--- a/src/task-dispatcher/td.hh
+++ b/src/task-dispatcher/td.hh
@@ -169,7 +169,10 @@ void submit(sync& sync, F&& func)
     static_assert(std::is_invocable_r_v<void, F>, "return must be void");
 
     container::task dispatch;
-    dispatch.lambda(cc::forward<F>(func));
+    if constexpr (std::is_class_v<F>)
+        dispatch.lambda(cc::forward<F>(func));
+    else
+        dispatch.lambda([=] { func(); });
     submit_raw(sync, &dispatch, 1);
 }
 


### PR DESCRIPTION
- Simply `container::task` to no longer use virtual type erasure
    Fixes TSan-reported vtable ctor/dtor data race in task
    (TSan still reports issues regarding the MPMC/MPSC queues, possibly false positives)
- Remove inline assembly for posix compiler `intrin::rdtsc`
- Fix compiler error regarding decaying lambdas in task ctor