### PR TITLE
num_logical_cores, num_physical_cores

### DIFF
--- a/src/task-dispatcher/common/system_info.cc
+++ b/src/task-dispatcher/common/system_info.cc
@@ -1,12 +1,62 @@
 #include "system_info.hh"
 
+#include <clean-core/macros.hh>
 #include <new>
 #include <thread>
 
-#ifdef _MSC_VER
+#ifdef CC_OS_WINDOWS
+#include <clean-core/array.hh>
+#include <clean-core/native/win32_sanitized.hh>
+#endif
+
+#ifdef CC_COMPILER_MSVC
 static_assert(td::system::l1_cacheline_size == std::hardware_destructive_interference_size, "L1 Cacheline size assumption wrong");
 #else
 // Clang doesn't support std::hardware_destructive_interference yet
 #endif
 
-unsigned const td::system::hardware_concurrency = std::thread::hardware_concurrency();
+unsigned td::system::num_logical_cores() noexcept { return std::thread::hardware_concurrency(); }
+
+unsigned td::system::num_physical_cores() noexcept
+{
+#ifdef CC_OS_WINDOWS
+    cc::array<std::byte> buffer;
+    auto const to_ptr = [](std::byte* raw) { return reinterpret_cast<SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX*>(raw); };
+    ::DWORD length = 0;
+
+    while (true)
+    {
+        auto const rc = ::GetLogicalProcessorInformationEx(RelationAll, to_ptr(buffer.data()), &length);
+
+        if (rc)
+            break;
+
+        if (::GetLastError() == ERROR_INSUFFICIENT_BUFFER)
+            buffer = buffer.uninitialized(length);
+        else
+            return 0;
+    }
+
+    auto res_num_cores = 0u;
+
+    auto prev_processor_info_size = 0u;
+    std::byte* cursor = buffer.data();
+    auto cursor_offset = 0u;
+    while (cursor_offset < length)
+    {
+        cursor += prev_processor_info_size;
+        auto const* const info_struct = to_ptr(cursor);
+
+        if (info_struct->Relationship == RelationProcessorCore)
+            ++res_num_cores;
+
+        cursor_offset += info_struct->Size;
+        prev_processor_info_size = info_struct->Size;
+    }
+
+    return res_num_cores;
+#else
+    CC_RUNTIME_ASSERT(false && "unimplemented");
+    return 0;
+#endif
+}

--- a/src/task-dispatcher/common/system_info.hh
+++ b/src/task-dispatcher/common/system_info.hh
@@ -4,9 +4,10 @@
 
 namespace td::system
 {
-// == Compile time system info ==
+// == Compile time architecture info ==
 inline size_t constexpr l1_cacheline_size = 64; // std::hardware_destructive_interference_size assumption, verified in .cc
 
 // == Run time system info ==
-extern unsigned const hardware_concurrency; // std::thread::hardware_concurrency()
+[[nodiscard]] unsigned num_logical_cores() noexcept;  // std::thread::hardware_concurrency
+[[nodiscard]] unsigned num_physical_cores() noexcept; // platform-specific, potentially expensive
 }

--- a/src/task-dispatcher/common/system_info.hh
+++ b/src/task-dispatcher/common/system_info.hh
@@ -9,5 +9,5 @@ inline size_t constexpr l1_cacheline_size = 64; // std::hardware_destructive_int
 
 // == Run time system info ==
 [[nodiscard]] unsigned num_logical_cores() noexcept;  // std::thread::hardware_concurrency
-[[nodiscard]] unsigned num_physical_cores() noexcept; // platform-specific, potentially expensive
+[[nodiscard]] unsigned num_physical_cores() noexcept; // platform-specific, expensive on Windows
 }

--- a/src/task-dispatcher/scheduler.cc
+++ b/src/task-dispatcher/scheduler.cc
@@ -504,7 +504,7 @@ td::Scheduler::Scheduler(scheduler_config const& config)
     mFreeCounters(config.max_num_counters)
 {
     CC_ASSERT(config.is_valid() && "Scheduler config invalid, use scheduler_config_t::validate()");
-    CC_ASSERT((config.num_threads <= system::hardware_concurrency) && "More threads than physical cores configured");
+    CC_ASSERT((config.num_threads <= system::num_logical_cores()) && "More threads than physical cores configured");
 
     static_assert(ATOMIC_INT_LOCK_FREE == 2 && ATOMIC_BOOL_LOCK_FREE == 2, "No lock-free atomics available on this platform");
     static_assert(invalid_fiber == std::numeric_limits<fiber_index_t>().max(), "Invalid fiber index corrupt");

--- a/src/task-dispatcher/scheduler.hh
+++ b/src/task-dispatcher/scheduler.hh
@@ -23,7 +23,7 @@ struct fiber_t;
 struct scheduler_config
 {
     unsigned num_fibers = 256;
-    unsigned num_threads = system::hardware_concurrency;
+    unsigned num_threads = system::num_logical_cores();
     unsigned max_num_counters = 512;
     unsigned max_num_tasks = 4096;
     cc::size_t fiber_stack_size = 64 * 1024;

--- a/src/task-dispatcher/td.hh
+++ b/src/task-dispatcher/td.hh
@@ -245,7 +245,7 @@ void submit_each_copy(sync& sync, F&& func, cc::span<T> vals)
 
 // Lambda called for each batch, with batch start and end
 template <class F>
-void submit_batched(sync& sync, F&& func, unsigned n, unsigned num_batches_max = td::system::hardware_concurrency * 4)
+void submit_batched(sync& sync, F&& func, unsigned n, unsigned num_batches_max = td::system::num_logical_cores() * 4)
 {
     static_assert(std::is_invocable_v<F, unsigned, unsigned>, "function must be invocable with batch start and end argument");
     static_assert(std::is_same_v<std::invoke_result_t<F, unsigned, unsigned>, void>, "return must be void");
@@ -266,7 +266,7 @@ void submit_batched(sync& sync, F&& func, unsigned n, unsigned num_batches_max =
 
 // Lambda called for each batch, with batch start, end, and batch index
 template <class F>
-void submit_batched_n(sync& sync, F&& func, unsigned n, unsigned num_batches_max = td::system::hardware_concurrency * 4)
+void submit_batched_n(sync& sync, F&& func, unsigned n, unsigned num_batches_max = td::system::num_logical_cores() * 4)
 {
     static_assert(std::is_invocable_v<F, unsigned, unsigned, unsigned>, "function must be invocable with batch start, end, and index argument");
     static_assert(std::is_same_v<std::invoke_result_t<F, unsigned, unsigned, unsigned>, void>, "return must be void");
@@ -431,7 +431,7 @@ template <class T, class F>
 }
 
 template <class F>
-[[nodiscard]] sync submit_batched(F&& func, unsigned n, unsigned num_batches_max = td::system::hardware_concurrency * 4)
+[[nodiscard]] sync submit_batched(F&& func, unsigned n, unsigned num_batches_max = td::system::num_logical_cores() * 4)
 {
     static_assert(std::is_invocable_v<F, unsigned, unsigned>, "function must be invocable with batch start and end argument");
     static_assert(std::is_same_v<std::invoke_result_t<F, unsigned, unsigned>, void>, "return must be void");
@@ -441,7 +441,7 @@ template <class F>
 }
 
 template <class F>
-[[nodiscard]] sync submit_batched_n(F&& func, unsigned n, unsigned num_batches_max = td::system::hardware_concurrency * 4)
+[[nodiscard]] sync submit_batched_n(F&& func, unsigned n, unsigned num_batches_max = td::system::num_logical_cores() * 4)
 {
     static_assert(std::is_invocable_v<F, unsigned, unsigned, unsigned>, "function must be invocable with batch start, end, and index argument");
     static_assert(std::is_same_v<std::invoke_result_t<F, unsigned, unsigned, unsigned>, void>, "return must be void");


### PR DESCRIPTION
- resolved potential static init issues with the `extern unsigned hardware_concurrency`
- added two functions instead:
    - `td::system::num_logical_cores()`, wraps `std::thread::hardware_concurrency`
    - `td::system::num_physical_cores()`, platform-specific implementation