### PR TITLE
Add optional heap-allocated lambda task support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,11 @@ project(task-dispatcher)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 # =========================================
+# options
+
+option(TD_ALLOW_HEAP_TASKS "If enabled, automatically create heap-allocated tasks for lambdas exceeding cacheline size" OFF)
+
+# =========================================
 # define library
 
 file(GLOB_RECURSE SOURCES
@@ -16,6 +21,10 @@ source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}/src" FILES ${SOURCES})
 add_library(task-dispatcher STATIC ${SOURCES})
 target_include_directories(task-dispatcher PUBLIC src/)
 target_link_libraries(task-dispatcher PUBLIC clean-core)
+
+if (TD_ALLOW_HEAP_TASKS)
+    target_compile_definitions(task-dispatcher PUBLIC TD_ALLOW_HEAP_TASKS)
+endif()
 
 # =========================================
 # set up compile flags

--- a/src/task-dispatcher/container/task.cc
+++ b/src/task-dispatcher/container/task.cc
@@ -1,4 +1,5 @@
 #include "task.hh"
 
 static_assert(sizeof(td::container::task) == td::system::l1_cacheline_size, "task exceeds cacheline size");
+static_assert(alignof(td::container::task) == alignof(std::max_align_t), "task risks misalignment");
 static_assert(std::is_trivial_v<td::container::task>, "task is not trivial");

--- a/src/task-dispatcher/scheduler.cc
+++ b/src/task-dispatcher/scheduler.cc
@@ -32,7 +32,7 @@ constexpr bool const gc_use_workstealing = false;
 // If true, let worker threads sleep 1ms while no jobs are available
 constexpr bool const gc_sleep_if_empty = true;
 
-// If true, print a warning to stderr if a deadlocks is heuristically detected
+// If true, print a warning to stderr if a deadlock is heuristically detected
 constexpr bool const gc_warn_deadlocks = true;
 }
 


### PR DESCRIPTION
With the `TD_ALLOW_HEAP_TASKS` cmake option (default: off), lambda-based tasks are automatically heap-allocated if their size exceeds the maximum task size, instead of failing a static assert (default behavior).