### PR TITLE
Fix Win32 CPU utilization bug, add alive assert in submit

### DIFF
--- a/src/task-dispatcher/td-lean.hh
+++ b/src/task-dispatcher/td-lean.hh
@@ -94,7 +94,12 @@ void launch_singlethreaded(F&& func)
 // Submit
 
 // Raw submit from constructed Task types
-inline void submit_raw(sync& sync, container::task* tasks, unsigned num) { td::Scheduler::Current().submitTasks(tasks, num, sync); }
+inline void submit_raw(sync& sync, container::task* tasks, unsigned num)
+{
+    CC_ASSERT(td::is_scheduler_alive() && "attempted submit outside of live scheduler");
+    td::Scheduler::Current().submitTasks(tasks, num, sync);
+}
+
 inline void submit_raw(sync& sync, cc::span<container::task> tasks) { submit_raw(sync, tasks.data(), unsigned(tasks.size())); }
 
 


### PR DESCRIPTION
- Fix a bug where win32 event_t would never become unsignalled, keeping worker fibers locked in busy-wait
- Assert `is_scheduler_alive` in `td::submit`